### PR TITLE
Fix Gripper Bug

### DIFF
--- a/dobotapi/effectors/gripper.py
+++ b/dobotapi/effectors/gripper.py
@@ -31,4 +31,4 @@ class Gripper:
     def close(self) -> None:
         "Closes gripper"
 
-        self._grip(False)
+        self._grip(True)


### PR DESCRIPTION
Changes `self._grip(False)` to `self._grip(True)` inside `close()`.

I gotta say: after a week of going through garbage Dobot documentation and code, this is the best I've seen. Kudos!

My only wishes are that it supported jogging and an "off" state for the gripper.