### PR TITLE
Fix Documentation Examples

### DIFF
--- a/docs/addons/conveyor-belt.md
+++ b/docs/addons/conveyor-belt.md
@@ -19,6 +19,7 @@ from time import sleep
 from dobotapi import Dobot
 
 bot = Dobot()
+bot.connect()
 
 # Speed can range from -1.0 to 1.0 (negative values move the belt in the opposite direction)
 bot.conveyor_belt.move(speed=1.0)

--- a/docs/addons/effectors.md
+++ b/docs/addons/effectors.md
@@ -17,6 +17,7 @@ import os
 from dobotapi import Dobot
 
 bot = Dobot()
+bot.connect()
 
 bot.suction_cup.suck() # Enable the suction cup
 
@@ -40,6 +41,7 @@ import os
 from dobotapi import Dobot
 
 bot = Dobot()
+bot.connect()
 
 bot.gripper.open() # Enable the suction cup
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,6 +34,7 @@ This tutorial will teach you how to connect and control the robot <span style="c
 from dobotapi import Dobot
 
 bot = Dobot()
+bot.connect()
 bot.close()
 ```
 


### PR DESCRIPTION
I noticed that `bot.connect()` is needed after `bot = Dobot()` or else it will show the following error.

```
serial.serialutil.PortNotOpenError: Attempting to use a port that is not open
```

Thus, I added the needed line to every example I could find.